### PR TITLE
Allow sending request content to custom QIODevice

### DIFF
--- a/pillowcore/HttpHandler.cpp
+++ b/pillowcore/HttpHandler.cpp
@@ -19,6 +19,12 @@ HttpHandler::HttpHandler(QObject *parent)
 {
 }
 
+bool HttpHandler::handleContent(HttpConnection *connection)
+{
+	connection->setContentDevice(NULL);
+	return false;
+}
+
 //
 // HttpHandlerStack
 //
@@ -26,6 +32,19 @@ HttpHandler::HttpHandler(QObject *parent)
 HttpHandlerStack::HttpHandlerStack(QObject *parent)
 	: HttpHandler(parent)
 {
+}
+
+bool HttpHandlerStack::handleContent(HttpConnection *connection)
+{
+	foreach (QObject* object, children())
+	{
+		HttpHandler* handler = qobject_cast<HttpHandler*>(object);
+
+		if (handler && handler->handleContent(connection))
+			return true;
+	}
+
+	return false;
 }
 
 bool HttpHandlerStack::handleRequest(Pillow::HttpConnection *connection)

--- a/pillowcore/HttpHandler.h
+++ b/pillowcore/HttpHandler.h
@@ -36,6 +36,7 @@ namespace Pillow
 		HttpHandler(QObject *parent = 0);
 
 	public slots:
+		virtual bool handleContent(Pillow::HttpConnection* connection);
 		virtual bool handleRequest(Pillow::HttpConnection* connection) = 0;
 	};
 
@@ -51,6 +52,7 @@ namespace Pillow
 		HttpHandlerStack(QObject* parent = 0);
 
 	public:
+		virtual bool handleContent(Pillow::HttpConnection* connection);
 		virtual bool handleRequest(Pillow::HttpConnection *connection);
 	};
 

--- a/pillowcore/HttpServer.cpp
+++ b/pillowcore/HttpServer.cpp
@@ -2,6 +2,7 @@
 #include "HttpConnection.h"
 #include <QtNetwork/QTcpSocket>
 #include <QtNetwork/QLocalSocket>
+#include <QMetaMethod>
 using namespace Pillow;
 
 //
@@ -36,6 +37,7 @@ namespace Pillow
 		HttpConnection* createConnection()
 		{
 			HttpConnection* connection = new HttpConnection(q_ptr);
+			QObject::connect(connection, SIGNAL(contentReady(Pillow::HttpConnection*)), q_ptr, SLOT(contentReady(Pillow::HttpConnection*)));
 			QObject::connect(connection, SIGNAL(requestReady(Pillow::HttpConnection*)), q_ptr, SIGNAL(requestReady(Pillow::HttpConnection*)));
 			QObject::connect(connection, SIGNAL(closed(Pillow::HttpConnection*)), q_ptr, SLOT(connection_closed(Pillow::HttpConnection*)));
 			return connection;
@@ -92,6 +94,21 @@ void HttpServer::incomingConnection(int socketDescriptor)
 		qWarning() << "HttpServer::incomingConnection: failed to set socket descriptor '" << socketDescriptor << "' on socket.";
 		delete socket;
 	}
+}
+
+void HttpServer::contentReady(HttpConnection *connection)
+{
+	foreach (QObject* object, children())
+	{
+		int methodIndex = object->metaObject()->indexOfMethod("handleContent(Pillow::HttpConnection*)");
+		if (methodIndex < 0)
+			continue;
+		QMetaMethod method = object->metaObject()->method(methodIndex);
+		if (method.invoke(object, Q_ARG(Pillow::HttpConnection *, connection)))
+			return;
+	}
+
+	connection->setContentDevice(NULL);
 }
 
 void HttpServer::connection_closed(Pillow::HttpConnection *connection)

--- a/pillowcore/HttpServer.h
+++ b/pillowcore/HttpServer.h
@@ -31,6 +31,7 @@ namespace Pillow
 		HttpServerPrivate* d_ptr;
 
 	private slots:
+		void contentReady(Pillow::HttpConnection* connection);
 		void connection_closed(Pillow::HttpConnection* request);
 
 	protected:


### PR DESCRIPTION
Subclasses of HttpHandler may implement handleContent() to analyze the headers during the transition between request headers and request content. Invoking setContentDevice(contentDevice) will continue the connection, where a NULL contentDevice will behave like originally intended (direct to memory), otherwise a valid QIODevice will be written to instead.